### PR TITLE
fix: escape # from url

### DIFF
--- a/src/components/Admin/Vods/Delete.tsx
+++ b/src/components/Admin/Vods/Delete.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import getConfig from "next/config";
 import { useState } from "react";
 import { useApi } from "../../../hooks/useApi";
+import { escapeURL } from "../../../util/util";
 
 const AdminVodDelete = ({ handleClose, vod }) => {
   const { publicRuntimeConfig } = getConfig();
@@ -54,7 +55,9 @@ const AdminVodDelete = ({ handleClose, vod }) => {
 
       <img
         style={{ width: "100%" }}
-        src={`${publicRuntimeConfig.CDN_URL}${vod.web_thumbnail_path}`}
+        src={`${publicRuntimeConfig.CDN_URL}${escapeURL(
+          vod.web_thumbnail_path
+        )}`}
       />
       <div style={{ float: "right", marginTop: "1rem" }}>
         <div style={{ display: "flex" }}>

--- a/src/components/Queue/Header.tsx
+++ b/src/components/Queue/Header.tsx
@@ -1,6 +1,7 @@
 import { Container, createStyles, Image, Text, Tooltip } from "@mantine/core";
 import dayjs from "dayjs";
 import getConfig from "next/config";
+import { escapeURL } from "../../util/util";
 
 const useStyles = createStyles((theme) => ({
   queueHeader: {
@@ -60,7 +61,8 @@ const QueueHeader = ({ queue }: Object) => {
           <div>
             <Image
               src={
-                publicRuntimeConfig.CDN_URL + queue.edges.vod.web_thumbnail_path
+                publicRuntimeConfig.CDN_URL +
+                escapeURL(queue.edges.vod.thumbnail_path)
               }
               width={160}
             />

--- a/src/components/Vod/Card.tsx
+++ b/src/components/Vod/Card.tsx
@@ -27,6 +27,7 @@ import { IconCircleCheck, IconMenu2 } from "@tabler/icons";
 import { ROLES } from "../../hooks/useJsxAuth";
 import { VodMenu } from "./Menu";
 import Link from "next/link";
+import { escapeURL } from "../../util/util";
 dayjs.extend(duration);
 dayjs.extend(localizedFormat);
 
@@ -176,7 +177,9 @@ const VideoCard = ({
           <a>
             <Image
               className={classes.videoImage}
-              src={`${publicRuntimeConfig.CDN_URL}${video.web_thumbnail_path}`}
+              src={`${publicRuntimeConfig.CDN_URL}${escapeURL(
+                video.web_thumbnail_path
+              )}`}
               onError={handleError}
               width={imageError ? "100%" : "100%"}
               height={imageError ? "5rem" : "100%"}

--- a/src/components/Vod/ChatPlayer.tsx
+++ b/src/components/Vod/ChatPlayer.tsx
@@ -4,6 +4,7 @@ import { createStyles } from "@mantine/core";
 import React, { useEffect, useRef } from "react";
 import vodDataBus from "./EventBus";
 import getConfig from "next/config";
+import { escapeURL } from "../../util/util";
 
 const useStyles = createStyles((theme) => ({
   chatPlayer: {
@@ -75,7 +76,7 @@ export const VodChatPlayer = ({ vod }: any) => {
       title: vod.title,
       sources: [
         {
-          src: `${publicRuntimeConfig.CDN_URL}${vod.chat_video_path}`,
+          src: `${publicRuntimeConfig.CDN_URL}${escapeURL(vod.chat_video_path)}`,
           type: "video/mp4",
         },
       ],

--- a/src/components/Vod/LoginRequred.tsx
+++ b/src/components/Vod/LoginRequred.tsx
@@ -3,6 +3,7 @@ import { IconLock } from "@tabler/icons";
 import getConfig from "next/config";
 import React from "react";
 import { Video } from "../../ganymede-defs";
+import { escapeURL } from "../../util/util";
 
 const useStyles = createStyles((theme) => ({
   container: {
@@ -46,7 +47,7 @@ const VodLoginRequired = (vod: Video) => {
 
   const getImageUrl = () => {
     if (vod.thumbnail_path) {
-      return `${publicRuntimeConfig.CDN_URL}${vod.thumbnail_path}`;
+      return `${publicRuntimeConfig.CDN_URL}${escapeURL(vod.thumbnail_path)}`;
     } else {
       return "/images/landing-hero.webp";
     }

--- a/src/components/Vod/VideoPlayer.tsx
+++ b/src/components/Vod/VideoPlayer.tsx
@@ -26,6 +26,7 @@ import {
 } from "@vidstack/react/icons";
 import ReactDOM from "react-dom";
 import TheaterModeIcon from "./TheaterModeIcon";
+import { escapeURL } from "../../util/util";
 
 const useStyles = createStyles((theme) => ({
   playerContainer: {
@@ -90,13 +91,17 @@ const NewVideoPlayer = ({ vod }: any) => {
       type = "application/x-mpegURL";
     }
 
-    setVideoSource(`${publicRuntimeConfig.CDN_URL}${vod.video_path}`);
+    setVideoSource(
+      `${publicRuntimeConfig.CDN_URL}${escapeURL(vod.video_path)}`
+    );
     setVideoType(type);
     setVideoTitle(vod.title);
 
     // If thumbnail
     if (vod.thumbnail_path) {
-      setVideoPoster(`${publicRuntimeConfig.CDN_URL}${vod.thumbnail_path}`);
+      setVideoPoster(
+        `${publicRuntimeConfig.CDN_URL}${escapeURL(vod.video_path)}`
+      );
     }
 
     // If captions

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,0 +1,3 @@
+export function escapeURL(str: string): string {
+  return str.replace(/#/g, "%23");
+}


### PR DESCRIPTION
- escape `#` from the url which caused requests to fail with `#` was in the url