### PR TITLE
fix(channel): add more elements per row on bigger screens

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -75,7 +75,11 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       md: "64em",
       lg: "74em",
       xl: "90em",
-      xxl: "100em"
+      xxl: "100em",
+      "3xl": "116em",
+      "4xl": "130em",
+      "5xl": "146em",
+      "6xl": "160em"
     },
     components: {
       Container: Container.extend({

--- a/src/pages/channels/index.tsx
+++ b/src/pages/channels/index.tsx
@@ -28,7 +28,7 @@ const ChannelsPage = () => {
     <div>
       <Container fluid={true}>
         <div style={{ marginTop: "1rem" }}>
-          <SimpleGrid cols={{ base: 1, sm: 4, md: 5, lg: 6 }} spacing="xs" verticalSpacing="xs">
+          <SimpleGrid cols={{ base: 1, sm: 4, md: 5, lg: 6, xl: 7, xxl: 8, "3xl": 9, "4xl": 10, "5xl": 11, "6xl": 12 }} spacing="xs" verticalSpacing="xs">
             {data.map((channel: any) => (
               <ChannelCard channel={channel} key={channel.id}></ChannelCard>
             ))}


### PR DESCRIPTION
Add up to 12 columns for the channel grid on bigger screen resolutions.

https://github.com/Zibbp/ganymede-frontend/assets/1197915/d7a538b4-73be-41a7-968f-14b2ccb6bca7