### PR TITLE
fix(chat): fallback emote tooltip text to fragment text when empty + use mantine tooltips

### DIFF
--- a/src/components/Vod/ChatMessage.tsx
+++ b/src/components/Vod/ChatMessage.tsx
@@ -16,12 +16,13 @@ const ChatMessage = ({ comment }: Comment) => {
         {comment.ganymede_formatted_badges &&
           comment.ganymede_formatted_badges.map(
             (badge: GanymedeFormattedBadge) => (
-              <img
-                className={classes.badge}
-                src={badge.url}
-                title={badge.title}
-                height="18"
-              />
+              <Tooltip label={badge.title} position="top">
+                <img
+                  className={classes.badge}
+                  src={badge.url}
+                  height="18"
+                />
+              </Tooltip>
             )
           )}
       </span>
@@ -49,25 +50,28 @@ const ChatMessage = ({ comment }: Comment) => {
                   </Text>
                 );
               case "emote":
+                const emoteName = fragment.emote?.name || fragment.text; // If no emote name, fallback on fragment text
                 if (fragment.emote?.height != 0 && fragment.emote?.width != 0) {
                   return (
-                    <img
-                      src={fragment.url}
-                      className={classes.emoteImage}
-                      height={fragment.emote?.height}
-                      alt={fragment.emote?.name}
-                      title={fragment.emote?.name}
-                    />
+                    <Tooltip label={emoteName} position="top">
+                      <img
+                        src={fragment.url}
+                        className={classes.emoteImage}
+                        height={fragment.emote?.height}
+                        alt={emoteName}
+                      />
+                    </Tooltip>
                   );
                 } else {
                   return (
-                    <img
-                      src={fragment.url}
-                      className={classes.emoteImage}
-                      alt={fragment.emote?.name}
-                      height={28}
-                      title={fragment.emote?.name}
-                    />
+                    <Tooltip label={emoteName} position="top">
+                      <img
+                        src={fragment.url}
+                        className={classes.emoteImage}
+                        alt={emoteName}
+                        height={28}
+                      />
+                    </Tooltip>
                   );
                 }
             }

--- a/src/components/Vod/ExperimentalChatPlayer.tsx
+++ b/src/components/Vod/ExperimentalChatPlayer.tsx
@@ -179,7 +179,9 @@ const ExperimentalChatPlayer = ({ vod }: any) => {
       // Process Twitch first party emotes
       if (comment.message.fragments.length > 0) {
         comment.message.fragments.forEach((fragment) => {
-          let ganymedeMessageFragment = {} as GanymedeFormattedMessageFragments;
+          let ganymedeMessageFragment = {
+            text: fragment.text
+          } as GanymedeFormattedMessageFragments;
           if (fragment.emoticon) {
             const emote = emoteMap.get(fragment.emoticon.emoticon_id);
             if (!emote) {


### PR DESCRIPTION
- Fix tooltips not showing for emotes with an empty name, use the fragment text of the emote in this case
- Use mantine tooltips on badges and emotes to fit the same style of tooltips used in other places

![image](https://github.com/Zibbp/ganymede-frontend/assets/1197915/9341ac53-05d0-4ce8-a171-a837d88ed3ca)
![image](https://github.com/Zibbp/ganymede-frontend/assets/1197915/aed752b3-a156-4644-8f89-bdd8530c9911)
