### PR TITLE
feat(multistream): Experimental multistream

### DIFF
--- a/src/components/Playlist/Header.tsx
+++ b/src/components/Playlist/Header.tsx
@@ -35,6 +35,7 @@ const PlaylistHeader = ({ playlist, handleOpen, handleDeleteOpen }: any) => {
 
             <Menu.Dropdown>
               <Menu.Label>Settings</Menu.Label>
+              <Menu.Item component="a" href={`/playlists/multistream/${playlist.id}`}>Multistream</Menu.Item>
               <Menu.Item onClick={() => handleOpen()}>Edit</Menu.Item>
               <Menu.Item onClick={() => handleDeleteOpen()} color="red">
                 Delete

--- a/src/components/Video/MultistreamTimeline.module.css
+++ b/src/components/Video/MultistreamTimeline.module.css
@@ -1,0 +1,71 @@
+.timelineGrid {
+  position: relative;
+  min-height: 5rem;
+  max-height: 5rem;
+  flex-shrink: 0;
+  overflow: auto;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.25rem;
+  margin: 0 1rem 1rem 1rem;
+}
+
+.timelineStreamerColumn {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.timelineBar {
+  position: relative;
+  height: 0.75rem;
+  border-radius: 0.25rem;
+  overflow: hidden;
+}
+
+.timelineBar:before {
+  content: "";
+  background: var(--mantine-color-violet-9);
+  opacity: 0.25;
+  position: absolute;
+  inset: 0;
+}
+
+.timelineBarActive {
+  pointer-events: none;
+  background-color: var(--mantine-color-violet-9);
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--bar-start);
+  width: var(--bar-length);
+}
+
+.offsetInput {
+  width: 4.5rem;
+}
+
+.playheadContainer {
+  position: absolute;
+  grid-column: 2 / 3;
+  grid-row: 1;
+  width: 100%;
+  height: 100%;
+}
+
+.playhead {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--playhead-position);
+  transform: translateX(-50%);
+  width: 0.125rem;
+  background-color: var(--mantine-color-grape-5);
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.playheadPreview {
+  background-color: var(--mantine-color-pink-5);
+  opacity: 0.75;
+}

--- a/src/components/Video/MultistreamTimeline.module.css
+++ b/src/components/Video/MultistreamTimeline.module.css
@@ -1,7 +1,5 @@
 .timelineGrid {
   position: relative;
-  min-height: 5rem;
-  max-height: 5rem;
   flex-shrink: 0;
   overflow: auto;
   display: grid;
@@ -39,6 +37,10 @@
   bottom: 0;
   left: var(--bar-start);
   width: var(--bar-length);
+}
+
+.gridInput {
+  width: 4.5rem;
 }
 
 .offsetInput {

--- a/src/components/Video/MultistreamTimeline.tsx
+++ b/src/components/Video/MultistreamTimeline.tsx
@@ -1,8 +1,9 @@
-import { ActionIcon, Center, Group, NumberInput, Stack, Tooltip } from "@mantine/core";
+import { ActionIcon, Center, Group, Image, NumberInput, Stack, Tooltip } from "@mantine/core";
 import classes from "./MultistreamTimeline.module.css"
-import { IconEye, IconEyeOff, IconPlayerPauseFilled, IconPlayerPlayFilled, IconRewindBackward5, IconRewindBackward60, IconRewindForward5, IconRewindForward60 } from "@tabler/icons-react";
-import React, { Fragment, useState } from "react";
+import { IconPlayerPauseFilled, IconPlayerPlayFilled, IconRewindBackward5, IconRewindBackward60, IconRewindForward5, IconRewindForward60 } from "@tabler/icons-react";
+import React, { Fragment, useRef, useState } from "react";
 import dayjs from "dayjs";
+import getConfig from "next/config";
 
 export type MultistreamTimelineProps = {
   seek: (time: number) => void;
@@ -18,10 +19,14 @@ export type MultistreamTimelineProps = {
   playingVodForStreamer: Record<string, Vod | null>;
   streamers: Record<string, {
     name: string
-    vods: Vod[]
+    vods: Vod[],
+    imagePath: string
   }>;
-  streamerViewState: Record<string, boolean>;
-  toggleView: (streamerId: string) => void;
+  gridWidth: number;
+  gridHeight: number;
+  setGridWidth: (width: number) => void;
+  setGridHeight: (height: number) => void;
+  onStreamerDragStart: () => void;
 }
 
 type Vod = {
@@ -30,7 +35,8 @@ type Vod = {
   streamed_at: string
 }
 
-export const MultistreamTimeline = ({ vodPlaybackOffsets, globalTime, startDateMs, endDateMs, playStartAtDate, seek, pause, play, playing, playingVodForStreamer, streamerViewState, toggleView, streamers, setVodOffset }: MultistreamTimelineProps) => {
+export const MultistreamTimeline = ({ vodPlaybackOffsets, globalTime, startDateMs, endDateMs, playStartAtDate, seek, pause, play, playing, playingVodForStreamer, streamers, setVodOffset, onStreamerDragStart, gridWidth, gridHeight, setGridWidth, setGridHeight }: MultistreamTimelineProps) => {
+  const { publicRuntimeConfig } = getConfig();
   const [timelineTooltipText, setTimelineTooltipText] = useState<string>("");
   const [hoverPlayheadDate, setHoverPlayheadDate] = useState<number | null>(null);
   const timeAtMousePosition = (timelineBar: HTMLDivElement | null, event: React.MouseEvent) => {
@@ -41,6 +47,8 @@ export const MultistreamTimeline = ({ vodPlaybackOffsets, globalTime, startDateM
     const globalTime = startDateMs! + percentage * timelineDurationMs;
     return globalTime;
   }
+
+  const streamerImageRefs = useRef<Record<string, HTMLImageElement | null>>({});
 
   const onTimelineClick = (timelineBar: HTMLDivElement | null, event: React.MouseEvent) => {
     const newGlobalTime = timeAtMousePosition(timelineBar, event);
@@ -65,6 +73,15 @@ export const MultistreamTimeline = ({ vodPlaybackOffsets, globalTime, startDateM
   const updateTimelineTooltip = (timelineBar: HTMLDivElement | null, event: React.PointerEvent) => {
     const timeUnderPointer = timeAtMousePosition(timelineBar, event);
     setTimelineTooltipText(timeUnderPointer != null ? dayjs(timeUnderPointer).format("YYYY/MM/DD HH:mm:ss") : "");
+  }
+
+  const onStreamerNameDragStart = (event: React.DragEvent, streamerId: string) => {
+    event.dataTransfer.setData("streamerid", streamerId);
+    event.dataTransfer.effectAllowed = 'move';
+    if (streamerImageRefs.current?.[streamerId]) {
+      event.dataTransfer.setDragImage(streamerImageRefs.current[streamerId], 0, 0);
+    }
+    onStreamerDragStart();
   }
 
   const timelineEnd = dayjs(endDateMs).format("YYYY/MM/DD HH:mm:ss")
@@ -122,12 +139,17 @@ export const MultistreamTimeline = ({ vodPlaybackOffsets, globalTime, startDateM
           onClick={() => seek(getCurrentTime() + 60000)}
         ><IconRewindForward60 /></ActionIcon>
       </Tooltip>
+
+      <NumberInput className={classes.gridInput} label="Grid width" value={gridWidth} onChange={(value) => setGridWidth(+value)} size="xs" step={1} min={1} />
+      <NumberInput className={classes.gridInput} label="Grid height" value={gridHeight} onChange={(value) => setGridHeight(+value)} size="xs" step={1} min={1} />
     </Group>
 
     <Center>
-      <div>
-        {dayjs(getCurrentTime()).format("YYYY/MM/DD HH:mm:ss")} / {timelineEnd}
-      </div>
+      <Group gap="sm">
+        <div>
+          {dayjs(getCurrentTime()).format("YYYY/MM/DD HH:mm:ss")} / {timelineEnd}
+        </div>
+      </Group>
     </Center>
 
     {
@@ -147,26 +169,28 @@ export const MultistreamTimeline = ({ vodPlaybackOffsets, globalTime, startDateM
           return (
             <Fragment key={streamer.name + "-timeline-row"}>
               <div className={classes.timelineStreamerColumn}>
-                {streamer.name}
-                <Tooltip label={streamerViewState[streamerId] ? "Hide streamer" : "Show streamer"}>
-                  <ActionIcon variant="subtle" color="violet" onClick={() => toggleView(streamerId)} aria-label={streamerViewState[streamerId] ? "Hide streamer" : "Show streamer"}>
-                    {streamerViewState[streamerId] ? <IconEye size="1.125rem" aria-label="Currently displayed" /> : <IconEyeOff size="1.125rem" aria-label="Currently hidden" />}
-                  </ActionIcon>
-                </Tooltip>
-                <NumberInput
-                  className={classes.offsetInput}
-                  size="xs"
-                  step={0.1}
-                  value={playingVod && vodPlaybackOffsets[playingVod.id] != null ? (vodPlaybackOffsets[playingVod.id] || 0) / 1000 : ''}
-                  placeholder="Offset"
-                  disabled={!playingVod}
-                  onChange={(value) => {
-                    if (!playingVod) return;
-                    const valAsNumber = Math.trunc(+value * 1000);
-                    if (isNaN(valAsNumber)) return;
-                    setVodOffset(playingVod.id, valAsNumber);
-                  }}
-                />
+                <Group gap='sm'>
+                  <div onDragStart={(e) => onStreamerNameDragStart(e, streamerId)} draggable="true">
+                    <Group gap="sm">
+                      <Image ref={(img) => { streamerImageRefs.current[streamerId] = img }} src={`${publicRuntimeConfig.CDN_URL}${streamer.imagePath}`} alt={streamer.name} w={'1.5em'} h={'1.5em'} radius={'1.5em'} />
+                      {streamer.name}
+                    </Group>
+                  </div>
+                  <NumberInput
+                    className={classes.offsetInput}
+                    size="xs"
+                    step={0.1}
+                    value={playingVod && vodPlaybackOffsets[playingVod.id] != null ? (vodPlaybackOffsets[playingVod.id] || 0) / 1000 : ''}
+                    placeholder="Offset"
+                    disabled={!playingVod}
+                    onChange={(value) => {
+                      if (!playingVod) return;
+                      const valAsNumber = Math.trunc(+value * 1000);
+                      if (isNaN(valAsNumber)) return;
+                      setVodOffset(playingVod.id, valAsNumber);
+                    }}
+                  />
+                </Group>
               </div>
               <div>{timelineBar}</div>
             </Fragment>

--- a/src/components/Video/MultistreamTimeline.tsx
+++ b/src/components/Video/MultistreamTimeline.tsx
@@ -33,6 +33,8 @@ type Vod = {
   id: string
   duration: number
   streamed_at: string
+  created_at: string
+  type: 'live' | 'archive'
 }
 
 export const MultistreamTimeline = ({ vodPlaybackOffsets, globalTime, startDateMs, endDateMs, playStartAtDate, seek, pause, play, playing, playingVodForStreamer, streamers, setVodOffset, onStreamerDragStart, gridWidth, gridHeight, setGridWidth, setGridHeight }: MultistreamTimelineProps) => {
@@ -159,7 +161,7 @@ export const MultistreamTimeline = ({ vodPlaybackOffsets, globalTime, startDateM
 
           const timelineBar = <div className={classes.timelineBar}>
             {streamer.vods.map(vod => <div key={vod.id + "-vod-timeline-online"} className={classes.timelineBarActive} style={{
-              '--bar-start': `${100 * (+new Date(vod.streamed_at) - startDateMs!) / timelineDurationMs}%`,
+              '--bar-start': `${100 * (+new Date(getVodStartDate(vod)) - startDateMs!) / timelineDurationMs}%`,
               '--bar-length': `${100 * 1000 * vod.duration / timelineDurationMs}%`,
             } as React.CSSProperties}></div>)}
           </div>
@@ -212,4 +214,14 @@ export const MultistreamTimeline = ({ vodPlaybackOffsets, globalTime, startDateM
       </div>
     }
   </Stack>
+}
+
+function getVodStartDate(vod: Vod): string {
+  if (!vod) {
+    return '';
+  }
+  if (vod.type === 'live') {
+    return vod.created_at;
+  }
+  return vod.streamed_at;
 }

--- a/src/components/Video/MultistreamTimeline.tsx
+++ b/src/components/Video/MultistreamTimeline.tsx
@@ -1,0 +1,191 @@
+import { ActionIcon, Center, Group, NumberInput, Stack, Tooltip } from "@mantine/core";
+import classes from "./MultistreamTimeline.module.css"
+import { IconEye, IconEyeOff, IconPlayerPauseFilled, IconPlayerPlayFilled, IconRewindBackward5, IconRewindBackward60, IconRewindForward5, IconRewindForward60 } from "@tabler/icons-react";
+import React, { Fragment, useState } from "react";
+import dayjs from "dayjs";
+
+export type MultistreamTimelineProps = {
+  seek: (time: number) => void;
+  pause: () => void;
+  play: () => void;
+  vodPlaybackOffsets: Record<string, number>;
+  globalTime: number;
+  startDateMs: number | null;
+  endDateMs: number | null;
+  playStartAtDate: number;
+  playing: boolean;
+  setVodOffset: (vodId: string, offset: number) => void;
+  playingVodForStreamer: Record<string, Vod | null>;
+  streamers: Record<string, {
+    name: string
+    vods: Vod[]
+  }>;
+  streamerViewState: Record<string, boolean>;
+  toggleView: (streamerId: string) => void;
+}
+
+type Vod = {
+  id: string
+  duration: number
+  streamed_at: string
+}
+
+export const MultistreamTimeline = ({ vodPlaybackOffsets, globalTime, startDateMs, endDateMs, playStartAtDate, seek, pause, play, playing, playingVodForStreamer, streamerViewState, toggleView, streamers, setVodOffset }: MultistreamTimelineProps) => {
+  const [timelineTooltipText, setTimelineTooltipText] = useState<string>("");
+  const [hoverPlayheadDate, setHoverPlayheadDate] = useState<number | null>(null);
+  const timeAtMousePosition = (timelineBar: HTMLDivElement | null, event: React.MouseEvent) => {
+    if (!timelineBar) return null;
+    const rect = timelineBar.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const percentage = x / rect.width;
+    const globalTime = startDateMs! + percentage * timelineDurationMs;
+    return globalTime;
+  }
+
+  const onTimelineClick = (timelineBar: HTMLDivElement | null, event: React.MouseEvent) => {
+    const newGlobalTime = timeAtMousePosition(timelineBar, event);
+    if (newGlobalTime == null) {
+      return;
+    }
+    seek(newGlobalTime);
+  }
+
+  const hideHoverPlayhead = () => {
+    setHoverPlayheadDate(null);
+  }
+  const updateHoverPlayhead = (timelineBar: HTMLDivElement | null, event: React.PointerEvent) => {
+    setHoverPlayheadDate(timeAtMousePosition(timelineBar, event));
+  }
+  const timelineDurationMs: number = startDateMs != null && endDateMs != null ? endDateMs - startDateMs : 0;
+
+  const getCurrentTime = () => {
+    return (playing ? (Date.now() - playStartAtDate) : 0) + globalTime
+  }
+
+  const updateTimelineTooltip = (timelineBar: HTMLDivElement | null, event: React.PointerEvent) => {
+    const timeUnderPointer = timeAtMousePosition(timelineBar, event);
+    setTimelineTooltipText(timeUnderPointer != null ? dayjs(timeUnderPointer).format("YYYY/MM/DD HH:mm:ss") : "");
+  }
+
+  const timelineEnd = dayjs(endDateMs).format("YYYY/MM/DD HH:mm:ss")
+
+  return <Stack gap="sm">
+    <Group justify="center" gap="xs">
+      <Tooltip label="Seek back 60 seconds" position="top">
+        <ActionIcon
+          size="sm"
+          variant="subtle"
+          color="violet"
+          aria-label="Seek back 60 seconds"
+          onClick={() => seek(getCurrentTime() - 60000)}
+        ><IconRewindBackward60 /></ActionIcon>
+      </Tooltip>
+
+      <Tooltip label="Seek back 5 seconds" position="top">
+        <ActionIcon
+          size="sm"
+          variant="subtle"
+          color="violet"
+          aria-label="Seek back 5 seconds"
+          onClick={() => seek(getCurrentTime() - 5000)}
+        ><IconRewindBackward5 /></ActionIcon>
+      </Tooltip>
+
+      <Tooltip label={playing ? "Pause" : "Play"} position="top">
+        <ActionIcon
+          onClick={() => { playing ? pause() : play() }}
+          size="md"
+          variant="subtle"
+          color="violet"
+          aria-label={playing ? "Pause" : "Play"}
+        >
+          {playing ? <IconPlayerPauseFilled /> : <IconPlayerPlayFilled />}
+        </ActionIcon>
+      </Tooltip>
+
+      <Tooltip label="Seek forward 5 seconds" position="top">
+        <ActionIcon
+          size="sm"
+          variant="subtle"
+          color="violet"
+          aria-label="Seek forward 5 seconds"
+          onClick={() => seek(getCurrentTime() + 5000)}
+        ><IconRewindForward5 /></ActionIcon>
+      </Tooltip>
+
+      <Tooltip label="Seek forward 60 seconds" position="top">
+        <ActionIcon
+          size="sm"
+          variant="subtle"
+          color="violet"
+          aria-label="Seek forward 60 seconds"
+          onClick={() => seek(getCurrentTime() + 60000)}
+        ><IconRewindForward60 /></ActionIcon>
+      </Tooltip>
+    </Group>
+
+    <Center>
+      <div>
+        {dayjs(getCurrentTime()).format("YYYY/MM/DD HH:mm:ss")} / {timelineEnd}
+      </div>
+    </Center>
+
+    {
+      startDateMs != null && endDateMs != null && <div className={classes.timelineGrid}>
+        {Object.keys(streamers).map((streamerId) => {
+          const streamer = streamers[streamerId]
+
+          const timelineBar = <div className={classes.timelineBar}>
+            {streamer.vods.map(vod => <div key={vod.id + "-vod-timeline-online"} className={classes.timelineBarActive} style={{
+              '--bar-start': `${100 * (+new Date(vod.streamed_at) - startDateMs!) / timelineDurationMs}%`,
+              '--bar-length': `${100 * 1000 * vod.duration / timelineDurationMs}%`,
+            } as React.CSSProperties}></div>)}
+          </div>
+
+          const playingVod = playingVodForStreamer[streamerId];
+
+          return (
+            <Fragment key={streamer.name + "-timeline-row"}>
+              <div className={classes.timelineStreamerColumn}>
+                {streamer.name}
+                <Tooltip label={streamerViewState[streamerId] ? "Hide streamer" : "Show streamer"}>
+                  <ActionIcon variant="subtle" color="violet" onClick={() => toggleView(streamerId)} aria-label={streamerViewState[streamerId] ? "Hide streamer" : "Show streamer"}>
+                    {streamerViewState[streamerId] ? <IconEye size="1.125rem" aria-label="Currently displayed" /> : <IconEyeOff size="1.125rem" aria-label="Currently hidden" />}
+                  </ActionIcon>
+                </Tooltip>
+                <NumberInput
+                  className={classes.offsetInput}
+                  size="xs"
+                  step={0.1}
+                  value={playingVod && vodPlaybackOffsets[playingVod.id] != null ? (vodPlaybackOffsets[playingVod.id] || 0) / 1000 : ''}
+                  placeholder="Offset"
+                  disabled={!playingVod}
+                  onChange={(value) => {
+                    if (!playingVod) return;
+                    const valAsNumber = Math.trunc(+value * 1000);
+                    if (isNaN(valAsNumber)) return;
+                    setVodOffset(playingVod.id, valAsNumber);
+                  }}
+                />
+              </div>
+              <div>{timelineBar}</div>
+            </Fragment>
+          )
+        })}
+
+        {
+          (() => {
+            let timelineBarRef: HTMLDivElement | null = null;
+
+            return <Tooltip.Floating label={timelineTooltipText}>
+              <div className={classes.playheadContainer} ref={el => timelineBarRef = el} onClick={(event) => onTimelineClick(timelineBarRef, event)} onPointerMove={(event) => { updateTimelineTooltip(timelineBarRef, event); updateHoverPlayhead(timelineBarRef, event) }} onPointerLeave={hideHoverPlayhead}>
+                <div className={classes.playhead} style={{ '--playhead-position': `${((getCurrentTime() - startDateMs) / timelineDurationMs) * 100}%` } as React.CSSProperties}></div>
+                {hoverPlayheadDate != null && <div className={`${classes.playhead} ${classes.playheadPreview}`} style={{ '--playhead-position': `${((hoverPlayheadDate - startDateMs) / timelineDurationMs) * 100}%` } as React.CSSProperties}></div>}
+              </div>
+            </Tooltip.Floating>
+          })()
+        }
+      </div>
+    }
+  </Stack>
+}

--- a/src/components/Video/SyncedVideoPlayer.module.css
+++ b/src/components/Video/SyncedVideoPlayer.module.css
@@ -1,0 +1,7 @@
+.mediaPlayer {
+    height: 100%;
+
+  video {
+    height: 100%;
+  }
+}

--- a/src/components/Video/SyncedVideoPlayer.module.css
+++ b/src/components/Video/SyncedVideoPlayer.module.css
@@ -1,7 +1,11 @@
 .mediaPlayer {
-    height: 100%;
+  height: 100%;
 
   video {
     height: 100%;
   }
+}
+
+.ganymedePoster {
+  object-fit: contain;
 }

--- a/src/components/Video/SyncedVideoPlayer.tsx
+++ b/src/components/Video/SyncedVideoPlayer.tsx
@@ -1,0 +1,119 @@
+import { MediaPlayer, MediaPlayerInstance, MediaProvider, MediaProviderInstance, Poster, Track } from "@vidstack/react";
+import { defaultLayoutIcons, DefaultVideoLayout } from '@vidstack/react/player/layouts/default';
+import getConfig from "next/config";
+import { useEffect, useRef, useState } from "react";
+import '@vidstack/react/player/styles/default/theme.css';
+import '@vidstack/react/player/styles/default/layouts/video.css';
+import classes from "./SyncedVideoPlayer.module.css"
+import { useInterval } from "@mantine/hooks";
+
+export type SyncedVideoPlayerProps = {
+    src: string;
+    vodId: string;
+    title: string;
+    poster: string;
+    time: number;
+    playing: boolean;
+    muted: boolean;
+    onUserSeek: (time: number) => void;
+    onUserPlay: () => void;
+    onUserPause: (pausedAtTime: number) => void;
+    onTimeUpdate: (currentTime: number) => void;
+}
+
+const SyncedVideoPlayer = ({ src, vodId, title, poster, time, playing, muted, onUserSeek, onUserPlay, onUserPause, onTimeUpdate }: SyncedVideoPlayerProps) => {
+    const { publicRuntimeConfig } = getConfig();
+    const player = useRef<MediaPlayerInstance>(null)
+    const mediaProvider = useRef<MediaProviderInstance>(null)
+    const [canPlay, setCanPlay] = useState(false)
+    const [justSynchonized, setJustSynchronized] = useState(false)
+
+    const onPlay = () => {
+        if (!player.current || playing) return;
+        console.log(`vodId: ${vodId} playing`)
+        onUserPlay()
+    }
+
+    const onPause = () => {
+        if (!player.current || !playing) return;
+        console.log(`vodId: ${vodId} pausing`)
+        onUserPause(player.current.currentTime)
+    }
+
+    useEffect(() => {
+        const currentPlayer = player.current
+        if (!currentPlayer || !canPlay) return;
+        console.log(`vodId: ${vodId} playing=${playing}`);
+        (async () => {
+            if (playing) {
+                currentPlayer.currentTime = time;
+                await (new Promise<void>(resolve => setTimeout(resolve, 1)));
+                await currentPlayer.play();
+            } else {
+                await (new Promise<void>(resolve => setTimeout(resolve, 1)));
+                await currentPlayer.pause();
+            }
+        })();
+    }, [playing, canPlay])
+
+    useEffect(() => {
+        if (!player.current) return;
+        player.current.muted = muted;
+    }, [muted])
+
+    const timeUpdateInterval = useInterval(() => {
+        // Don't update if it's a rounding frame time problem
+        if (!player.current || Math.abs(player.current.currentTime - time) < 0.01) return;
+        onTimeUpdate(player.current.currentTime);
+    }, 2000)
+
+    useEffect(() => {
+        if (!player.current) return;
+        // Synchronize time if in pause or out of sync by half a second
+        if (Math.abs(player.current.currentTime - time) > 0.5 || !playing) {
+            player.current.currentTime = time;
+            setJustSynchronized(true);
+        }
+        timeUpdateInterval.start();
+        return timeUpdateInterval.stop;
+    }, [time])
+
+    const onSeeking = (currentTime: number) => {
+        if (!player.current) return;
+        setJustSynchronized((justSynchonized) => {
+            if (justSynchonized) {
+                return false;
+            }
+            onUserSeek(currentTime);
+            return false;
+        })
+    }
+
+    return (
+        <MediaPlayer
+            className={classes.mediaPlayer}
+            src={src}
+            ref={player}
+            aspect-ratio={16 / 9}
+            crossorigin
+            onPlay={onPlay}
+            onPause={onPause}
+            onSeeking={onSeeking}
+            onCanPlay={() => setCanPlay(true)}
+            playsinline
+        >
+            <MediaProvider ref={mediaProvider}>
+                <Poster className="vds-poster" src={poster} alt={title} />
+                <Track
+                    src={`${publicRuntimeConfig.API_URL}/api/v1/chapter/video/${vodId}/webvtt`}
+                    kind="chapters"
+                    default={true}
+                />
+            </MediaProvider>
+
+            <DefaultVideoLayout icons={defaultLayoutIcons} />
+        </MediaPlayer>
+    )
+};
+
+export default SyncedVideoPlayer;

--- a/src/components/Video/SyncedVideoPlayer.tsx
+++ b/src/components/Video/SyncedVideoPlayer.tsx
@@ -5,115 +5,71 @@ import { useEffect, useRef, useState } from "react";
 import '@vidstack/react/player/styles/default/theme.css';
 import '@vidstack/react/player/styles/default/layouts/video.css';
 import classes from "./SyncedVideoPlayer.module.css"
-import { useInterval } from "@mantine/hooks";
 
 export type SyncedVideoPlayerProps = {
-    src: string;
-    vodId: string;
-    title: string;
-    poster: string;
-    time: number;
-    playing: boolean;
-    muted: boolean;
-    onUserSeek: (time: number) => void;
-    onUserPlay: () => void;
-    onUserPause: (pausedAtTime: number) => void;
-    onTimeUpdate: (currentTime: number) => void;
+  src: string;
+  vodId: string;
+  title: string;
+  poster: string;
+  time: number;
+  playing: boolean;
+  muted: boolean;
 }
 
-const SyncedVideoPlayer = ({ src, vodId, title, poster, time, playing, muted, onUserSeek, onUserPlay, onUserPause, onTimeUpdate }: SyncedVideoPlayerProps) => {
-    const { publicRuntimeConfig } = getConfig();
-    const player = useRef<MediaPlayerInstance>(null)
-    const mediaProvider = useRef<MediaProviderInstance>(null)
-    const [canPlay, setCanPlay] = useState(false)
-    const [justSynchonized, setJustSynchronized] = useState(false)
+const SyncedVideoPlayer = ({ src, vodId, title, poster, time, playing, muted }: SyncedVideoPlayerProps) => {
+  const { publicRuntimeConfig } = getConfig();
+  const player = useRef<MediaPlayerInstance>(null)
+  const mediaProvider = useRef<MediaProviderInstance>(null)
+  const [canPlay, setCanPlay] = useState(false)
 
-    const onPlay = () => {
-        if (!player.current || playing) return;
-        console.log(`vodId: ${vodId} playing`)
-        onUserPlay()
-    }
+  useEffect(() => {
+    const currentPlayer = player.current
+    if (!currentPlayer || !canPlay) return;
+    (async () => {
+      if (playing) {
+        currentPlayer.currentTime = time;
+        await (new Promise<void>(resolve => setTimeout(resolve, 1)));
+        await currentPlayer.play();
+      } else {
+        await (new Promise<void>(resolve => setTimeout(resolve, 1)));
+        await currentPlayer.pause();
+      }
+    })();
+  }, [playing, canPlay])
 
-    const onPause = () => {
-        if (!player.current || !playing) return;
-        console.log(`vodId: ${vodId} pausing`)
-        onUserPause(player.current.currentTime)
-    }
+  useEffect(() => {
+    if (!player.current) return;
+    player.current.muted = muted;
+  }, [muted])
 
-    useEffect(() => {
-        const currentPlayer = player.current
-        if (!currentPlayer || !canPlay) return;
-        console.log(`vodId: ${vodId} playing=${playing}`);
-        (async () => {
-            if (playing) {
-                currentPlayer.currentTime = time;
-                await (new Promise<void>(resolve => setTimeout(resolve, 1)));
-                await currentPlayer.play();
-            } else {
-                await (new Promise<void>(resolve => setTimeout(resolve, 1)));
-                await currentPlayer.pause();
-            }
-        })();
-    }, [playing, canPlay])
+  useEffect(() => {
+    if (!player.current || Math.abs(player.current.currentTime - time) < 0.2) return;
+    player.current.currentTime = time;
+  }, [time])
 
-    useEffect(() => {
-        if (!player.current) return;
-        player.current.muted = muted;
-    }, [muted])
+  return (
+    <MediaPlayer
+      className={classes.mediaPlayer}
+      src={src}
+      ref={player}
+      aspect-ratio={16 / 9}
+      crossOrigin
+      onCanPlay={() => setCanPlay(true)}
+      playsInline
+      muted={muted}
+    >
+      <MediaProvider ref={mediaProvider}>
+        <Poster className={`${classes.ganymedePoster} vds-poster`} src={poster} alt={title} />
+        <Track
+          src={`${publicRuntimeConfig.API_URL}/api/v1/chapter/video/${vodId}/webvtt`}
+          kind="chapters"
+          default={true}
+        />
+      </MediaProvider>
 
-    const timeUpdateInterval = useInterval(() => {
-        // Don't update if it's a rounding frame time problem
-        if (!player.current || Math.abs(player.current.currentTime - time) < 0.01) return;
-        onTimeUpdate(player.current.currentTime);
-    }, 2000)
-
-    useEffect(() => {
-        if (!player.current) return;
-        // Synchronize time if in pause or out of sync by half a second
-        if (Math.abs(player.current.currentTime - time) > 0.5 || !playing) {
-            player.current.currentTime = time;
-            setJustSynchronized(true);
-        }
-        timeUpdateInterval.start();
-        return timeUpdateInterval.stop;
-    }, [time])
-
-    const onSeeking = (currentTime: number) => {
-        if (!player.current) return;
-        setJustSynchronized((justSynchonized) => {
-            if (justSynchonized) {
-                return false;
-            }
-            onUserSeek(currentTime);
-            return false;
-        })
-    }
-
-    return (
-        <MediaPlayer
-            className={classes.mediaPlayer}
-            src={src}
-            ref={player}
-            aspect-ratio={16 / 9}
-            crossorigin
-            onPlay={onPlay}
-            onPause={onPause}
-            onSeeking={onSeeking}
-            onCanPlay={() => setCanPlay(true)}
-            playsinline
-        >
-            <MediaProvider ref={mediaProvider}>
-                <Poster className="vds-poster" src={poster} alt={title} />
-                <Track
-                    src={`${publicRuntimeConfig.API_URL}/api/v1/chapter/video/${vodId}/webvtt`}
-                    kind="chapters"
-                    default={true}
-                />
-            </MediaProvider>
-
-            <DefaultVideoLayout icons={defaultLayoutIcons} />
-        </MediaPlayer>
-    )
+      <DefaultVideoLayout icons={defaultLayoutIcons} />
+    </MediaPlayer>
+  )
 };
 
 export default SyncedVideoPlayer;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import type { AppContext, AppProps } from "next/app";
 import App from "next/app";
 import {
   Container,
+  Drawer,
   MantineProvider,
   createTheme,
   em,
@@ -73,6 +74,18 @@ export default function MyApp({ Component, pageProps }: AppProps) {
                 : rem(size),
           },
         }),
+      }),
+      Drawer: Drawer.extend({
+        vars: (_, { size }) => {
+          if (size === 'auto') {
+            return {
+              root: {
+                '--drawer-size': 'auto'
+              }
+            }
+          }
+          return { root: {} }
+        }
       }),
     },
     colors: {

--- a/src/pages/playlists/multistream/[playlistId].tsx
+++ b/src/pages/playlists/multistream/[playlistId].tsx
@@ -1,0 +1,252 @@
+import getConfig from "next/config";
+import useUserStore from "../../../store/user";
+import Head from "next/head";
+import VodLoginRequired from "../../../components/Vod/LoginRequred";
+import { useQuery } from "@tanstack/react-query";
+import { useApi } from "../../../hooks/useApi";
+import GanymedeLoader from "../../../components/Utils/GanymedeLoader";
+import React, { Fragment, useState } from "react";
+import SyncedVideoPlayer from "../../../components/Vod/SyncedVideoPlayer";
+import { escapeURL } from "../../../util/util";
+import classes from "./playlistMultistream.module.css"
+import { ActionIcon, Flex, NumberInput, Text } from "@mantine/core";
+import { IconEye, IconEyeOff } from "@tabler/icons-react";
+
+export async function getServerSideProps(context: any) {
+    const { playlistId } = context.query;
+    return {
+      props: {
+        playlistId,
+      },
+    };
+  }
+
+const PlaylistMultistream = (props: { playlistId: string }) => {
+    const { publicRuntimeConfig } = getConfig();
+    const user = useUserStore((state) => state);
+    const [streamerViewState, setStreamerViewState] = useState<Record<string, boolean>>({});
+    const [streamerPlaybackOffsets, setStreamerPlaybackOffsets] = useState<Record<string, number>>({});
+
+    const checkLoginRequired = () => {
+        if (
+            publicRuntimeConfig.REQUIRE_LOGIN &&
+            publicRuntimeConfig.REQUIRE_LOGIN == "true" &&
+            !user.isLoggedIn
+        ) {
+            return true;
+        }
+        return false;
+    };
+
+    const { isLoading, error, data } = useQuery({
+      queryKey: ["playlist", props.playlistId],
+      queryFn: () =>
+        useApi(
+          {
+            method: "GET",
+            url: `/api/v1/playlist/${props.playlistId}`,
+          },
+          false
+        ).then((res) => res?.data),
+    });
+
+    const [playing, setPlaying] = useState<boolean>(false);
+    const [globalTime, setGlobalTime] = useState<number>(0);
+    const [seeked, setSeeked] = useState<boolean>(false);
+
+    if (error) return <div>failed to load</div>;
+    if (isLoading) return <GanymedeLoader />;
+    if (data.edges.vods.length === 0) return <div>Empty playlist, unable to start multistream.</div>;
+
+    let startDateMs: number | null = null;
+    let endDateMs: number | null = null;
+    const streamers: Record<string, {
+        name: string
+        vods: Vod[]
+    }> = {}
+
+    for (let i = 0; i < data.edges.vods.length; i++) {
+        const vod = data.edges.vods[i];
+        const vodStartDateMs = +new Date(vod.streamed_at)
+        if (startDateMs == null || vodStartDateMs < startDateMs) {
+            startDateMs = vodStartDateMs;
+        }
+        const vodEndDateMs = vodStartDateMs + vod.duration * 1000;
+        if (endDateMs == null || endDateMs < vodEndDateMs) {
+            endDateMs = vodEndDateMs;
+        }
+
+        if (!streamers[vod.edges.channel.id]) {
+            streamers[vod.edges.channel.id] = {
+                name: vod.edges.channel.name,
+                vods: []
+            }
+        }
+
+        streamers[vod.edges.channel.id].vods.push(vod)
+    }
+    let timelineDurationMs: number = startDateMs != null && endDateMs != null ? endDateMs - startDateMs : 0;
+    let _seeked = false;
+    if (seeked)
+        setSeeked(false);
+
+    const seek = (newGlobalTime: number) => {
+        _seeked = true;
+        setSeeked(true);
+        setGlobalTime(newGlobalTime);
+    }
+
+    if (startDateMs != null && globalTime < startDateMs) {
+        seek(startDateMs);
+    }
+
+    const onUserPlay = () => {
+        setPlaying(true);
+    }
+
+    const onUserPause = (pausedAtGlobalTime: number) => {
+        setPlaying(false);
+        setGlobalTime(pausedAtGlobalTime)
+    }
+
+    const onUserSeek = (time: number) => {
+        seek(time);
+    }
+
+    const onTimeUpdate = (currentTime: number) => {
+        setGlobalTime(currentTime);
+    }
+
+    const onTimelineClick = (timelineBar: HTMLDivElement | null, event: React.MouseEvent) => {
+        if (!timelineBar) return;
+        const rect = timelineBar.getBoundingClientRect();
+        const x = event.clientX - rect.left;
+        const percentage = x / rect.width;
+        const newGlobalTime = startDateMs! + percentage * timelineDurationMs;
+        seek(newGlobalTime);
+    }
+
+    const toggleView = (streamerId: string) => {
+        setStreamerViewState((prevState) => {
+            const newState = { ...prevState };
+            newState[streamerId] = !newState[streamerId];
+            return newState;
+        })
+    }
+
+    const playerTiles = Object.keys(streamers).map((streamerId) => {
+        if (!streamerViewState[streamerId]) {
+            return null;
+        }
+        const streamer = streamers[streamerId];
+        const playbackOffset = (streamerPlaybackOffsets[streamerId] || 0) / 1000;
+        const playingVod = getVodAtTime(streamer.vods, globalTime + playbackOffset);
+        if (!playingVod) {
+            return <div className={`${classes.streamerOffline} ${classes.playerTile}`} key={streamer.name + "-no-playing-vod"}>
+                <Text size="xl" span>
+                    { streamer.name }<br />
+                    <Text size="xl" fw={700} span>OFFLINE</Text>
+                </Text>
+            </div>
+        }
+        const vodTime = (globalTime - (+new Date(playingVod?.streamed_at))) / 1000 + playbackOffset;
+        const toGlobalTime = (time: number) => (time - playbackOffset) * 1000 + (+new Date(playingVod.streamed_at));
+        return (
+            <div className={classes.playerTile} key={playingVod.id + "-vod-player"}>
+                <SyncedVideoPlayer
+                    src={`${publicRuntimeConfig.CDN_URL}${escapeURL(playingVod.video_path)}`}
+                    vodId={playingVod.id}
+                    title={playingVod.title}
+                    poster={`${publicRuntimeConfig.CDN_URL}${escapeURL(playingVod.video_path)}`}
+                    time={vodTime}
+                    playing={playing}
+                    muted={true}
+                    onUserSeek={(time) => onUserSeek(toGlobalTime(time))}
+                    onUserPlay={onUserPlay}
+                    onUserPause={(pausedAtTime) => onUserPause(toGlobalTime(pausedAtTime))}
+                    onTimeUpdate={(currentTime) => onTimeUpdate(toGlobalTime(currentTime))}
+                />
+            </div>
+        )
+    })
+
+    return (
+        <div>
+            <Head>
+                <title>{data.name} - Ganymede</title>
+            </Head>
+            { checkLoginRequired() && <VodLoginRequired {...data} /> ||
+                <div className={classes.pageWrapper}>
+                    <div className={classes.videosGrid} style={{ '--players-count': playerTiles.reduce((acc, player) => acc + +(player != null), 0) } as React.CSSProperties}>
+                        { playerTiles }
+                    </div>
+                    {
+                        startDateMs != null && endDateMs != null && <div className={classes.timelineGrid}>
+                            { Object.keys(streamers).map((streamerId) => {
+                                const streamer = streamers[streamerId]
+
+                                let timelineBarRef: HTMLDivElement | null = null;
+
+                                const timelineBar = <div className={classes.timelineBar} ref={el => timelineBarRef = el} onClick={(event) => onTimelineClick(timelineBarRef, event)}>
+                                    { streamer.vods.map(vod => <div key={vod.id + "-vod-timeline-online"} className={classes.timelineBarActive} style={{
+                                        '--bar-start': `${100 * (+new Date(vod.streamed_at) - startDateMs!) / timelineDurationMs}%`,
+                                        '--bar-length': `${100 * 1000 * vod.duration / timelineDurationMs}%`,
+                                    } as React.CSSProperties}></div>) }
+                                </div>
+
+                                return (
+                                    <Fragment key={streamer.name + "-timeline-row"}>
+                                        <div className={classes.timelineStreamerColumn}>
+                                            { streamer.name }
+                                            <ActionIcon variant="transparent" onClick={() => toggleView(streamerId)}>
+                                                { streamerViewState[streamerId] ? <IconEye size="1.125rem" /> : <IconEyeOff size="1.125rem" /> }
+                                            </ActionIcon>
+                                            <NumberInput
+                                                className={classes.offsetInput}
+                                                step={0.1}
+                                                value={(streamerPlaybackOffsets[streamerId] || 0) / 1000}
+                                                placeholder="Offset"
+                                                onChange={(value) => {
+                                                    const valAsNumber = +value * 1000;
+                                                    if (isNaN(valAsNumber)) return;
+                                                    setStreamerPlaybackOffsets((prevState) => {
+                                                        const newState = { ...prevState };
+                                                        newState[streamerId] = valAsNumber;
+                                                        return newState;
+                                                    })
+                                                }}
+                                            />
+                                        </div>
+                                        <div>{ timelineBar }</div>
+                                    </Fragment>
+                                )
+                            })}
+                        </div>
+                    }
+                </div>
+            }
+        </div>
+    )
+}
+
+type Vod = {
+    id: string
+    video_path: string
+    duration: number
+    streamed_at: string
+    title: string
+}
+
+function getVodAtTime(vods: Vod[], time: number): Vod | null {
+    for (let i = 0; i < vods.length; i++) {
+        const vod = vods[i];
+        const vodStartDateMs = +new Date(vod.streamed_at)
+        const vodEndDateMs = vodStartDateMs + vod.duration * 1000;
+        if (vodStartDateMs <= time && time <= vodEndDateMs) {
+            return vod;
+        }
+    }
+    return null;
+}
+
+export default PlaylistMultistream;

--- a/src/pages/playlists/multistream/[playlistId].tsx
+++ b/src/pages/playlists/multistream/[playlistId].tsx
@@ -44,7 +44,7 @@ const PlaylistMultistream = (props: { playlistId: string }) => {
         useApi(
           {
             method: "GET",
-            url: `/api/v1/playlist/${props.playlistId}`,
+            url: `/api/v1/playlist/${props.playlistId}?with_multistream_info=true`,
           },
           false
         ).then((res) => res?.data),
@@ -188,12 +188,12 @@ const PlaylistMultistream = (props: { playlistId: string }) => {
     const playingVodForStreamer: Record<string, Vod | null> = {};
 
     const playerTiles = Object.keys(streamers).map((streamerId) => {
-        if (!streamerViewState[streamerId]) {
-            return null;
-        }
         const streamer = streamers[streamerId];
         const playingVod = getVodAtTime(streamer.vods, vodPlaybackOffsets, globalTime);
         playingVodForStreamer[streamerId] = playingVod;
+        if (!streamerViewState[streamerId]) {
+            return null;
+        }
         if (!playingVod) {
             return <div className={`${classes.streamerOffline} ${classes.playerTile}`} key={streamer.name + "-no-playing-vod"}>
                 <Text size="xl" span>

--- a/src/pages/playlists/multistream/[playlistId].tsx
+++ b/src/pages/playlists/multistream/[playlistId].tsx
@@ -59,7 +59,7 @@ const PlaylistMultistream = (props: { playlistId: string }) => {
       await useApi(
         {
           method: "PUT",
-          url: `/api/v1/playlist/${playlistId}/delay`,
+          url: `/api/v1/playlist/${playlistId}/multistream/delay`,
           withCredentials: true,
           data: {
             vod_id: vodId,

--- a/src/pages/playlists/multistream/[playlistId].tsx
+++ b/src/pages/playlists/multistream/[playlistId].tsx
@@ -131,6 +131,29 @@ const PlaylistMultistream = (props: { playlistId: string }) => {
 
       _streamers[vod.edges.channel.id].vods.push(vod)
     }
+
+    // COmpute default view
+    const streamersCount = Object.keys(_streamers).length;
+    let rows = 1;
+    if (streamersCount > 3) {
+      rows = 2;
+    }
+    let columns = Math.ceil(streamersCount / rows);
+    setGridWidth(columns);
+    setGridHeight(rows);
+    let i = 0;
+    let defaultViewState: Record<string, { tileX: number; tileY: number; tileWidth: number; tileHeight: number } | null> = {}
+    for (let streamerId in _streamers) {
+      defaultViewState[streamerId] = {
+        tileX: i % columns,
+        tileY: Math.floor(i / columns),
+        tileWidth: 1,
+        tileHeight: 1,
+      }
+      i++;
+    }
+    setStreamerViewState(defaultViewState);
+
     setStartDateMs(_startDateMs)
     setEndDateMs(_endDateMs)
     setStreamers(_streamers)

--- a/src/pages/playlists/multistream/[playlistId].tsx
+++ b/src/pages/playlists/multistream/[playlistId].tsx
@@ -112,7 +112,7 @@ const PlaylistMultistream = (props: { playlistId: string }) => {
     }> = {};
     for (let i = 0; i < data.edges.vods.length; i++) {
       const vod = data.edges.vods[i];
-      const vodStartDateMs = +new Date(vod.streamed_at)
+      const vodStartDateMs = +new Date(getVodStartDate(vod))
       if (_startDateMs == null || vodStartDateMs < _startDateMs) {
         _startDateMs = vodStartDateMs;
       }
@@ -275,7 +275,7 @@ const PlaylistMultistream = (props: { playlistId: string }) => {
     }
     const playbackOffset = (vodPlaybackOffsets[playingVod.id] || 0) / 1000;
     const currentGlobalTime = (playing ? (Date.now() - playStartAtDate) : 0) + globalTime
-    const vodTime = (currentGlobalTime - (+new Date(playingVod?.streamed_at))) / 1000 + playbackOffset;
+    const vodTime = (currentGlobalTime - (+new Date(getVodStartDate(playingVod)))) / 1000 + playbackOffset;
     return (
       <ResizableTile
         className={classes.playerTile}
@@ -437,7 +437,19 @@ type Vod = {
   video_path: string
   duration: number
   streamed_at: string
+  created_at: string
+  type: 'live' | 'archive'
   title: string
+}
+
+function getVodStartDate(vod: Vod): string {
+  if (!vod) {
+    return '';
+  }
+  if (vod.type === 'live') {
+    return vod.created_at;
+  }
+  return vod.streamed_at;
 }
 
 function getVodAtTime(vods: Vod[], vodPlaybackOffsets: Record<string, number>, time: number): Vod | null {
@@ -445,7 +457,7 @@ function getVodAtTime(vods: Vod[], vodPlaybackOffsets: Record<string, number>, t
     const vod = vods[i];
     const playbackOffset = (vodPlaybackOffsets[vod.id] || 0) / 1000
     const offsettedTime = time + playbackOffset;
-    const vodStartDateMs = +new Date(vod.streamed_at)
+    const vodStartDateMs = +new Date(getVodStartDate(vod))
     const vodEndDateMs = vodStartDateMs + vod.duration * 1000;
     if (vodStartDateMs <= offsettedTime && offsettedTime <= vodEndDateMs) {
       return vod;

--- a/src/pages/playlists/multistream/[playlistId].tsx
+++ b/src/pages/playlists/multistream/[playlistId].tsx
@@ -1,326 +1,294 @@
 import getConfig from "next/config";
 import useUserStore from "../../../store/user";
 import Head from "next/head";
-import VodLoginRequired from "../../../components/Vod/LoginRequred";
+import VodLoginRequired from "../../../components/Video/LoginRequred";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useApi } from "../../../hooks/useApi";
 import GanymedeLoader from "../../../components/Utils/GanymedeLoader";
-import React, { Fragment, useEffect, useState } from "react";
-import SyncedVideoPlayer from "../../../components/Vod/SyncedVideoPlayer";
+import React, { useEffect, useState } from "react";
+import SyncedVideoPlayer from "../../../components/Video/SyncedVideoPlayer";
 import { escapeURL } from "../../../util/util";
 import classes from "./playlistMultistream.module.css"
-import { ActionIcon, Flex, NumberInput, Text } from "@mantine/core";
-import { IconEye, IconEyeOff } from "@tabler/icons-react";
+import { ActionIcon, Drawer, Text } from "@mantine/core";
+import { IconChevronUp } from "@tabler/icons-react";
+import { useDisclosure, useInterval } from "@mantine/hooks";
+import { MultistreamTimeline } from "../../../components/Video/MultistreamTimeline";
 
 export async function getServerSideProps(context: any) {
-    const { playlistId } = context.query;
-    return {
-      props: {
-        playlistId,
-      },
-    };
-  }
+  const { playlistId } = context.query;
+  return {
+    props: {
+      playlistId,
+    },
+  };
+}
 
 const PlaylistMultistream = (props: { playlistId: string }) => {
-    const { publicRuntimeConfig } = getConfig();
-    const user = useUserStore((state) => state);
-    const [streamerViewState, setStreamerViewState] = useState<Record<string, boolean>>({});
-    const [vodPlaybackOffsets, setVodPlaybackOffsets] = useState<Record<string, number>>({});
+  const { publicRuntimeConfig } = getConfig();
+  const user = useUserStore((state) => state);
+  const [streamerViewState, setStreamerViewState] = useState<Record<string, boolean>>({});
+  const [vodPlaybackOffsets, setVodPlaybackOffsets] = useState<Record<string, number>>({});
 
-    const checkLoginRequired = () => {
-        if (
-            publicRuntimeConfig.REQUIRE_LOGIN &&
-            publicRuntimeConfig.REQUIRE_LOGIN == "true" &&
-            !user.isLoggedIn
-        ) {
-            return true;
-        }
-        return false;
-    };
+  const checkLoginRequired = () => {
+    if (
+      publicRuntimeConfig.REQUIRE_LOGIN &&
+      publicRuntimeConfig.REQUIRE_LOGIN == "true" &&
+      !user.isLoggedIn
+    ) {
+      return true;
+    }
+    return false;
+  };
 
-    const { isLoading, error, data } = useQuery({
-      queryKey: ["playlist", props.playlistId],
-      queryFn: () =>
-        useApi(
-          {
-            method: "GET",
-            url: `/api/v1/playlist/${props.playlistId}?with_multistream_info=true`,
-          },
-          false
-        ).then((res) => res?.data),
-    });
-
-    const updateVodOffset = useMutation({
-        mutationKey: ["save-delay"],
-        mutationFn: async ({ playlistId, vodId, delayMs }: { playlistId: string, vodId: string, delayMs: number }) => {
-            await useApi(
-                {
-                    method: "PUT",
-                    url: `/api/v1/playlist/${playlistId}/delay`,
-                    withCredentials: true,
-                    data: {
-                        vod_id: vodId,
-                        delay_ms: delayMs,
-                    }
-                },
-                false
-            ).catch((err) => {
-                console.log("Error saving delay", err);
-            });
+  const { isLoading, error, data } = useQuery({
+    queryKey: ["playlist", props.playlistId],
+    queryFn: () =>
+      useApi(
+        {
+          method: "GET",
+          url: `/api/v1/playlist/${props.playlistId}?with_multistream_info=true`,
         },
-      })
+        false
+      ).then((res) => res?.data),
+  });
 
-    const [playing, setPlaying] = useState<boolean>(false);
-    const [globalTime, setGlobalTime] = useState<number>(0);
-    const [seeked, setSeeked] = useState<boolean>(false);
-    const [startDateMs, setStartDateMs] = useState<number | null>(null);
-    const [endDateMs, setEndDateMs] = useState<number | null>(null);
-    const [streamers, setStreamers] = useState<Record<string, {
-        name: string
-        vods: Vod[]
-    }>>({});
+  const updateVodOffset = useMutation({
+    mutationKey: ["save-delay"],
+    mutationFn: async ({ playlistId, vodId, delayMs }: { playlistId: string, vodId: string, delayMs: number }) => {
+      await useApi(
+        {
+          method: "PUT",
+          url: `/api/v1/playlist/${playlistId}/delay`,
+          withCredentials: true,
+          data: {
+            vod_id: vodId,
+            delay_ms: delayMs,
+          }
+        },
+        false
+      ).catch((err) => {
+        console.log("Error saving delay", err);
+      });
+    },
+  })
 
-    useEffect(() => {
-        if (!data) {
-            return;
+  const [playing, setPlaying] = useState<boolean>(false);
+  const [playStartAtDate, setPlayStartAtDate] = useState<number>(0);
+  const [globalTime, setGlobalTime] = useState<number>(0);
+  const [globalTimeUpdate, setGlobalTimeUpdate] = useState<number>(0);
+  const [startDateMs, setStartDateMs] = useState<number | null>(null);
+  const [endDateMs, setEndDateMs] = useState<number | null>(null);
+  const [streamers, setStreamers] = useState<Record<string, {
+    name: string
+    vods: Vod[]
+  }>>({});
+
+  const [opened, { open, close }] = useDisclosure(true);
+
+  const videoCheckInterval = useInterval(() => {
+    setGlobalTimeUpdate((playing ? (Date.now() - playStartAtDate) : 0) + globalTime)
+  }, 1000)
+
+  // Update start and end of the timeline
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+    let _startDateMs: number | null = null;
+    let _endDateMs: number | null = null;
+    let _streamers: Record<string, {
+      name: string
+      vods: Vod[]
+    }> = {};
+    for (let i = 0; i < data.edges.vods.length; i++) {
+      const vod = data.edges.vods[i];
+      const vodStartDateMs = +new Date(vod.streamed_at)
+      if (_startDateMs == null || vodStartDateMs < _startDateMs) {
+        _startDateMs = vodStartDateMs;
+      }
+      const vodEndDateMs = vodStartDateMs + vod.duration * 1000;
+      if (_endDateMs == null || _endDateMs < vodEndDateMs) {
+        _endDateMs = vodEndDateMs;
+      }
+
+      if (!_streamers[vod.edges.channel.id]) {
+        _streamers[vod.edges.channel.id] = {
+          name: vod.edges.channel.name,
+          vods: []
         }
-        let _startDateMs: number | null = null;
-        let _endDateMs: number | null = null;
-        let _streamers: Record<string, {
-            name: string
-            vods: Vod[]
-        }> = {};
-        for (let i = 0; i < data.edges.vods.length; i++) {
-            const vod = data.edges.vods[i];
-            const vodStartDateMs = +new Date(vod.streamed_at)
-            if (_startDateMs == null || vodStartDateMs < _startDateMs) {
-                _startDateMs = vodStartDateMs;
-            }
-            const vodEndDateMs = vodStartDateMs + vod.duration * 1000;
-            if (_endDateMs == null || _endDateMs < vodEndDateMs) {
-                _endDateMs = vodEndDateMs;
-            }
+      }
 
-            if (!_streamers[vod.edges.channel.id]) {
-                _streamers[vod.edges.channel.id] = {
-                    name: vod.edges.channel.name,
-                    vods: []
-                }
-            }
+      _streamers[vod.edges.channel.id].vods.push(vod)
+    }
+    setStartDateMs(_startDateMs)
+    setEndDateMs(_endDateMs)
+    setStreamers(_streamers)
 
-            _streamers[vod.edges.channel.id].vods.push(vod)
+    setVodPlaybackOffsets((prevState) => {
+      const newState = { ...prevState };
+      if (data.edges.multistream_info) {
+        for (let i = 0; i < data.edges.multistream_info.length; i++) {
+          const multistreamInfo = data.edges.multistream_info[i];
+          newState[multistreamInfo.edges.vod.id] = multistreamInfo.delay_ms;
         }
-        setStartDateMs(_startDateMs)
-        setEndDateMs(_endDateMs)
-        setStreamers(_streamers)
-
-        setVodPlaybackOffsets((prevState) => {
-            const newState = { ...prevState };
-            if (data.edges.multistream_info) {
-                for (let i = 0; i < data.edges.multistream_info.length; i++) {
-                    const multistreamInfo = data.edges.multistream_info[i];
-                    newState[multistreamInfo.edges.vod.id] = multistreamInfo.delay_ms;
-                }
-            }
-            return newState;
-        })
-    }, [data])
-
-    if (error) return <div>failed to load</div>;
-    if (isLoading) return <GanymedeLoader />;
-    if (data.edges.vods.length === 0) return <div>Empty playlist, unable to start multistream.</div>;
-
-    let timelineDurationMs: number = startDateMs != null && endDateMs != null ? endDateMs - startDateMs : 0;
-    if (seeked)
-        setSeeked(false);
-
-    const seek = (newGlobalTime: number) => {
-        setSeeked(true);
-        setGlobalTime(newGlobalTime);
-    }
-
-    if (startDateMs != null && globalTime < startDateMs) {
-        seek(startDateMs);
-    }
-
-    const onUserPlay = () => {
-        setPlaying(true);
-    }
-
-    const onUserPause = (pausedAtGlobalTime: number) => {
-        setPlaying(false);
-        setGlobalTime(pausedAtGlobalTime)
-    }
-
-    const onUserSeek = (time: number) => {
-        seek(time);
-    }
-
-    const onTimeUpdate = (currentTime: number) => {
-        setGlobalTime(currentTime);
-    }
-
-    const timeAtMousePosition = (timelineBar: HTMLDivElement | null, event: React.MouseEvent) => {
-        if (!timelineBar) return null;
-        const rect = timelineBar.getBoundingClientRect();
-        const x = event.clientX - rect.left;
-        const percentage = x / rect.width;
-        const globalTime = startDateMs! + percentage * timelineDurationMs;
-        return globalTime;
-    }
-
-    const onTimelineClick = (timelineBar: HTMLDivElement | null, event: React.MouseEvent) => {
-        const newGlobalTime = timeAtMousePosition(timelineBar, event);
-        if (newGlobalTime == null) {
-            return;
-        }
-        seek(newGlobalTime);
-    }
-
-    const toggleView = (streamerId: string) => {
-        setStreamerViewState((prevState) => {
-            const newState = { ...prevState };
-            newState[streamerId] = !newState[streamerId];
-            return newState;
-        })
-    }
-
-    const playingVodForStreamer: Record<string, Vod | null> = {};
-
-    const playerTiles = Object.keys(streamers).map((streamerId) => {
-        const streamer = streamers[streamerId];
-        const playingVod = getVodAtTime(streamer.vods, vodPlaybackOffsets, globalTime);
-        playingVodForStreamer[streamerId] = playingVod;
-        if (!streamerViewState[streamerId]) {
-            return null;
-        }
-        if (!playingVod) {
-            return <div className={`${classes.streamerOffline} ${classes.playerTile}`} key={streamer.name + "-no-playing-vod"}>
-                <Text size="xl" span>
-                    { streamer.name }<br />
-                    <Text size="xl" fw={700} span>OFFLINE</Text>
-                </Text>
-            </div>
-        }
-        const playbackOffset = (vodPlaybackOffsets[playingVod.id] || 0) / 1000;
-        const vodTime = (globalTime - (+new Date(playingVod?.streamed_at))) / 1000 + playbackOffset;
-        const toGlobalTime = (time: number) => (time - playbackOffset) * 1000 + (+new Date(playingVod.streamed_at));
-        return (
-            <div className={classes.playerTile} key={playingVod.id + "-vod-player"}>
-                <SyncedVideoPlayer
-                    src={`${publicRuntimeConfig.CDN_URL}${escapeURL(playingVod.video_path)}`}
-                    vodId={playingVod.id}
-                    title={playingVod.title}
-                    poster={`${publicRuntimeConfig.CDN_URL}${escapeURL(playingVod.video_path)}`}
-                    time={vodTime}
-                    playing={playing}
-                    muted={true}
-                    onUserSeek={(time) => onUserSeek(toGlobalTime(time))}
-                    onUserPlay={onUserPlay}
-                    onUserPause={(pausedAtTime) => onUserPause(toGlobalTime(pausedAtTime))}
-                    onTimeUpdate={(currentTime) => onTimeUpdate(toGlobalTime(currentTime))}
-                />
-            </div>
-        )
+      }
+      return newState;
     })
+  }, [data])
 
+  useEffect(() => {
+    videoCheckInterval.stop()
+    if (!playing) {
+      return
+    }
+    videoCheckInterval.start();
+    return videoCheckInterval.stop;
+  }, [playing]);
+
+  if (error) return <div>failed to load</div>;
+  if (isLoading) return <GanymedeLoader />;
+  if (data.edges.vods.length === 0) return <div>Empty playlist, unable to start multistream.</div>;
+
+  const seek = (newGlobalTime: number) => {
+    setPlayStartAtDate(Date.now());
+    setGlobalTime(newGlobalTime);
+    setGlobalTimeUpdate(newGlobalTime);
+  }
+
+  if (startDateMs != null && globalTime < startDateMs) {
+    seek(startDateMs);
+  }
+
+  const onUserPlay = () => {
+    setPlayStartAtDate(Date.now());
+    setPlaying(true);
+  }
+
+  const onUserPause = (pausedAtGlobalTime: number) => {
+    setPlaying(false);
+    setGlobalTime(pausedAtGlobalTime)
+    setGlobalTimeUpdate(pausedAtGlobalTime);
+  }
+
+  const toggleView = (streamerId: string) => {
+    setStreamerViewState((prevState) => {
+      const newState = { ...prevState };
+      newState[streamerId] = !newState[streamerId];
+      return newState;
+    })
+  }
+
+  const playingVodForStreamer: Record<string, Vod | null> = {};
+
+  const playerTiles = Object.keys(streamers).map((streamerId) => {
+    const streamer = streamers[streamerId];
+    const playingVod = getVodAtTime(streamer.vods, vodPlaybackOffsets, globalTimeUpdate);
+    playingVodForStreamer[streamerId] = playingVod;
+    if (!streamerViewState[streamerId]) {
+      return null;
+    }
+    if (!playingVod) {
+      return <div className={`${classes.streamerOffline} ${classes.playerTile}`} key={streamer.name + "-no-playing-vod"}>
+        <Text size="xl" span>
+          {streamer.name}<br />
+          <Text size="xl" fw={700} span>OFFLINE</Text>
+        </Text>
+      </div>
+    }
+    const playbackOffset = (vodPlaybackOffsets[playingVod.id] || 0) / 1000;
+    const currentGlobalTime = (playing ? (Date.now() - playStartAtDate) : 0) + globalTime
+    const vodTime = (currentGlobalTime - (+new Date(playingVod?.streamed_at))) / 1000 + playbackOffset;
     return (
-        <div>
-            <Head>
-                <title>{data.name} - Ganymede</title>
-            </Head>
-            { checkLoginRequired() && <VodLoginRequired {...data} /> ||
-                <div className={classes.pageWrapper}>
-                    <div className={classes.videosGrid} style={{ '--players-count': playerTiles.reduce((acc, player) => acc + +(player != null), 0) } as React.CSSProperties}>
-                        { playerTiles }
-                    </div>
-                    {
-                        startDateMs != null && endDateMs != null && <div className={classes.timelineGrid}>
-                            { Object.keys(streamers).map((streamerId) => {
-                                const streamer = streamers[streamerId]
-
-                                const timelineBar = <div className={classes.timelineBar}>
-                                    { streamer.vods.map(vod => <div key={vod.id + "-vod-timeline-online"} className={classes.timelineBarActive} style={{
-                                        '--bar-start': `${100 * (+new Date(vod.streamed_at) - startDateMs!) / timelineDurationMs}%`,
-                                        '--bar-length': `${100 * 1000 * vod.duration / timelineDurationMs}%`,
-                                    } as React.CSSProperties}></div>) }
-                                </div>
-
-                                const playingVod = playingVodForStreamer[streamerId];
-
-                                return (
-                                    <Fragment key={streamer.name + "-timeline-row"}>
-                                        <div className={classes.timelineStreamerColumn}>
-                                            { streamer.name }
-                                            <ActionIcon variant="transparent" onClick={() => toggleView(streamerId)}>
-                                                { streamerViewState[streamerId] ? <IconEye size="1.125rem" /> : <IconEyeOff size="1.125rem" /> }
-                                            </ActionIcon>
-                                            <NumberInput
-                                                className={classes.offsetInput}
-                                                size="xs"
-                                                step={0.1}
-                                                value={playingVod && vodPlaybackOffsets[playingVod.id] != null ? (vodPlaybackOffsets[playingVod.id] || 0) / 1000 : ''}
-                                                placeholder="Offset"
-                                                disabled={!playingVod}
-                                                onChange={(value) => {
-                                                    if (!playingVod) return;
-                                                    const valAsNumber = Math.trunc(+value * 1000);
-                                                    if (isNaN(valAsNumber)) return;
-                                                    setVodPlaybackOffsets((prevState) => {
-                                                        const newState = { ...prevState };
-                                                        newState[playingVod.id] = valAsNumber;
-                                                        return newState;
-                                                    })
-                                                    updateVodOffset.mutate({
-                                                        playlistId: props.playlistId,
-                                                        vodId: playingVod.id,
-                                                        delayMs: valAsNumber,
-                                                    })
-                                                }}
-                                            />
-                                        </div>
-                                        <div>{ timelineBar }</div>
-                                    </Fragment>
-                                )
-                            })}
-
-                            {
-                                (() => {
-                                    let timelineBarRef: HTMLDivElement | null = null;
-
-                                    return (<div className={classes.playheadContainer} ref={el => timelineBarRef = el} onClick={(event) => onTimelineClick(timelineBarRef, event)}>
-                                        <div className={classes.playhead} style={{ '--playhead-position': `${((globalTime - startDateMs) / timelineDurationMs) * 100}%` }as React.CSSProperties}></div>
-                                    </div>)
-                                })()
-                            }
-                        </div>
-                    }
-                </div>
-            }
-        </div>
+      <div className={classes.playerTile} key={playingVod.id + "-vod-player"}>
+        <SyncedVideoPlayer
+          src={`${publicRuntimeConfig.CDN_URL}${escapeURL(playingVod.video_path)}`}
+          vodId={playingVod.id}
+          title={playingVod.title}
+          poster={`${publicRuntimeConfig.CDN_URL}${escapeURL(playingVod.web_thumbnail_path)}`}
+          time={vodTime}
+          playing={playing}
+          muted={true}
+        />
+      </div>
     )
+  })
+
+  return (
+    <div>
+      <Head>
+        <title>{data.name} - Ganymede Multistream</title>
+      </Head>
+      {checkLoginRequired() && <VodLoginRequired {...data} /> ||
+        <div className={classes.pageWrapper}>
+          <div className={classes.videosGrid} style={{ '--players-count': playerTiles.reduce((acc, player) => acc + +(player != null), 0) } as React.CSSProperties}>
+            {playerTiles}
+          </div>
+          <div className={classes.timelineOpenButtonContainer}>
+            <ActionIcon
+              onClick={open}
+              size="sm"
+              color="violet"
+              variant="light"
+            >
+              <IconChevronUp />
+            </ActionIcon>
+          </div>
+          <Drawer opened={opened} onClose={close} position="bottom" size="auto" overlayProps={{ backgroundOpacity: 0.1 }}>
+            <MultistreamTimeline
+              play={onUserPlay}
+              pause={() => { onUserPause(globalTime + Date.now() - playStartAtDate) }}
+              endDateMs={endDateMs}
+              startDateMs={startDateMs}
+              globalTime={globalTime}
+              playing={playing}
+              playingVodForStreamer={playingVodForStreamer}
+              streamers={streamers}
+              streamerViewState={streamerViewState}
+              toggleView={toggleView}
+              playStartAtDate={playStartAtDate}
+              seek={seek}
+              setVodOffset={(vodId, offset) => {
+                setVodPlaybackOffsets((prevState) => {
+                  const newState = { ...prevState };
+                  newState[vodId] = offset;
+                  return newState;
+                })
+                updateVodOffset.mutate({
+                  playlistId: props.playlistId,
+                  vodId: vodId,
+                  delayMs: offset,
+                })
+              }}
+              vodPlaybackOffsets={vodPlaybackOffsets}
+            />
+          </Drawer>
+        </div>
+      }
+    </div>
+  )
 }
 
 type Vod = {
-    id: string
-    video_path: string
-    duration: number
-    streamed_at: string
-    title: string
+  id: string
+  web_thumbnail_path: string
+  video_path: string
+  duration: number
+  streamed_at: string
+  title: string
 }
 
 function getVodAtTime(vods: Vod[], vodPlaybackOffsets: Record<string, number>, time: number): Vod | null {
-    for (let i = 0; i < vods.length; i++) {
-        const vod = vods[i];
-        const playbackOffset = (vodPlaybackOffsets[vod.id] || 0) / 1000
-        const offsettedTime = time + playbackOffset;
-        const vodStartDateMs = +new Date(vod.streamed_at)
-        const vodEndDateMs = vodStartDateMs + vod.duration * 1000;
-        if (vodStartDateMs <= offsettedTime && offsettedTime <= vodEndDateMs) {
-            return vod;
-        }
+  for (let i = 0; i < vods.length; i++) {
+    const vod = vods[i];
+    const playbackOffset = (vodPlaybackOffsets[vod.id] || 0) / 1000
+    const offsettedTime = time + playbackOffset;
+    const vodStartDateMs = +new Date(vod.streamed_at)
+    const vodEndDateMs = vodStartDateMs + vod.duration * 1000;
+    if (vodStartDateMs <= offsettedTime && offsettedTime <= vodEndDateMs) {
+      return vod;
     }
-    return null;
+  }
+  return null;
 }
 
 export default PlaylistMultistream;

--- a/src/pages/playlists/multistream/playlistMultistream.module.css
+++ b/src/pages/playlists/multistream/playlistMultistream.module.css
@@ -1,0 +1,72 @@
+.pageWrapper {
+    height: calc(100vh - 60px);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.videosGrid {
+    flex: 1;
+    max-height: 100%;
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.playerTile {
+    --max-per-row: 2;
+    width: calc(100% / min(var(--players-count), var(--max-per-row)));
+    max-height: 100%;
+
+    @media (min-aspect-ratio: 1.9) {
+        --max-per-row: 3;
+    }
+    @media (max-aspect-ratio: 0.9) {
+        --max-per-row: 1;
+    }
+}
+
+.streamerOffline {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+
+.timelineGrid {
+    min-height: 5rem;
+    max-height: 5rem;
+    flex-shrink: 0;
+    overflow: auto;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 0.25rem;
+    margin: 0 1rem 1rem 1rem;
+}
+
+.timelineStreamerColumn {
+    display: flex;
+    gap: 0.25rem;
+}
+
+.timelineBar {
+    background-color: currentColor;
+    position: relative;
+    height: 0.75rem;
+    border-radius: 0.25rem;
+    overflow: hidden;
+}
+
+.timelineBarActive {
+    pointer-events: none;
+    background-color: var(--mantine-color-violet-9);
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: var(--bar-start);
+    width: var(--bar-length);
+}
+
+.offsetInput {
+    width: 5rem;
+}

--- a/src/pages/playlists/multistream/playlistMultistream.module.css
+++ b/src/pages/playlists/multistream/playlistMultistream.module.css
@@ -68,5 +68,5 @@
 }
 
 .offsetInput {
-    width: 5rem;
+    width: 5.75rem;
 }

--- a/src/pages/playlists/multistream/playlistMultistream.module.css
+++ b/src/pages/playlists/multistream/playlistMultistream.module.css
@@ -33,6 +33,7 @@
 }
 
 .timelineGrid {
+    position: relative;
     min-height: 5rem;
     max-height: 5rem;
     flex-shrink: 0;
@@ -50,11 +51,18 @@
 }
 
 .timelineBar {
-    background-color: currentColor;
     position: relative;
     height: 0.75rem;
     border-radius: 0.25rem;
     overflow: hidden;
+}
+
+.timelineBar:before {
+    content: "";
+    background: var(--mantine-color-violet-9);
+    opacity: 0.25;
+    position: absolute;
+    inset: 0;
 }
 
 .timelineBarActive {
@@ -69,4 +77,24 @@
 
 .offsetInput {
     width: 5.75rem;
+}
+
+.playheadContainer {
+    position: absolute;
+    grid-column: 2 / 3;
+    grid-row: 1;
+    width: 100%;
+    height: 100%;
+}
+
+.playhead {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: var(--playhead-position);
+    transform: translateX(-50%);
+    width: 0.125rem;
+    background-color: var(--mantine-color-grape-5);
+    opacity: 0.75;
+    pointer-events: none;
 }

--- a/src/pages/playlists/multistream/playlistMultistream.module.css
+++ b/src/pages/playlists/multistream/playlistMultistream.module.css
@@ -1,29 +1,87 @@
 .pageWrapper {
   height: calc(100vh - 60px);
   display: flex;
-  flex-direction: column;
-  gap: 1rem;
 }
 
 .videosGrid {
   flex: 1;
-  max-height: 100%;
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  grid-template-columns: repeat(var(--grid-columns-count), minmax(0, 1fr));
+  grid-template-rows: repeat(var(--grid-rows-count), minmax(0, 1fr));
+
+  &.dropEnabled .dropTile {
+    pointer-events: auto;
+    opacity: 0.25;
+  }
+
+  &.dropEnabled > :not(.dropTile) {
+    pointer-events: none;
+  }
+
+  &.resizeMode > * {
+    pointer-events: none;
+  }
+}
+
+.resizeOverlay {
+  position: absolute;
+  left: calc(100% * var(--tile-x) / var(--grid-columns-count));
+  top: calc(100% * var(--tile-y) / var(--grid-rows-count));
+  width: calc(100% * var(--tile-width) / var(--grid-columns-count));
+  height: calc(100% * var(--tile-height) / var(--grid-rows-count));
+  opacity: 0.2;
+  background: var(--mantine-color-violet-5);
+  pointer-events: none;
+  transition: all 0.2s;
+  z-index: 150;
+}
+
+.resizableTile {
+  position: relative;
+
+  & > .topLeftHandle {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 1rem;
+    height: 1rem;
+    user-select: none;
+    touch-action: none;
+    cursor: move;
+    z-index: 150;
+  }
+
+  & > .bottomRightHandle {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 1rem;
+    height: 1rem;
+    user-select: none;
+    touch-action: none;
+    cursor: nwse-resize;
+    z-index: 150;
+  }
+
+  & > .topRightHandle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 1rem;
+    height: 1rem;
+    user-select: none;
+    touch-action: none;
+    cursor: not-allowed;
+    z-index: 150;
+  }
 }
 
 .playerTile {
-  --max-per-row: 2;
-  width: calc(100% / min(var(--players-count), var(--max-per-row)));
-  max-height: 100%;
-
-  @media (min-aspect-ratio: 1.9) {
-    --max-per-row: 3;
-  }
-
-  @media (max-aspect-ratio: 0.9) {
-    --max-per-row: 1;
-  }
+  grid-column: var(--tile-x);
+  grid-row: var(--tile-y);
 }
 
 .streamerOffline {
@@ -31,6 +89,24 @@
   justify-content: center;
   align-items: center;
   text-align: center;
+  border: 0.125rem solid var(--mantine-color-dark-5);
+}
+
+.dropTile {
+  opacity: 0;
+  background: var(--mantine-color-dark-7);
+  border: 0.125rem solid var(--mantine-color-dark-5);
+  grid-column: var(--tile-x);
+  grid-row: var(--tile-y);
+  pointer-events: none;
+  transition: all 0.2s;
+  z-index: 150;
+}
+
+.dropTileHovered {
+  opacity: 0.5;
+  background: var(--mantine-color-violet-5);
+  border: 0.125rem solid var(--mantine-color-violet-7);
 }
 
 .timelineOpenButtonContainer {

--- a/src/pages/playlists/multistream/playlistMultistream.module.css
+++ b/src/pages/playlists/multistream/playlistMultistream.module.css
@@ -1,100 +1,53 @@
 .pageWrapper {
-    height: calc(100vh - 60px);
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
+  height: calc(100vh - 60px);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .videosGrid {
-    flex: 1;
-    max-height: 100%;
-    display: flex;
-    flex-wrap: wrap;
+  flex: 1;
+  max-height: 100%;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .playerTile {
-    --max-per-row: 2;
-    width: calc(100% / min(var(--players-count), var(--max-per-row)));
-    max-height: 100%;
+  --max-per-row: 2;
+  width: calc(100% / min(var(--players-count), var(--max-per-row)));
+  max-height: 100%;
 
-    @media (min-aspect-ratio: 1.9) {
-        --max-per-row: 3;
-    }
-    @media (max-aspect-ratio: 0.9) {
-        --max-per-row: 1;
-    }
+  @media (min-aspect-ratio: 1.9) {
+    --max-per-row: 3;
+  }
+
+  @media (max-aspect-ratio: 0.9) {
+    --max-per-row: 1;
+  }
 }
 
 .streamerOffline {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
 }
 
-.timelineGrid {
-    position: relative;
-    min-height: 5rem;
-    max-height: 5rem;
-    flex-shrink: 0;
-    overflow: auto;
-    display: grid;
-    grid-template-columns: auto 1fr;
-    align-items: center;
-    gap: 0.25rem;
-    margin: 0 1rem 1rem 1rem;
+.timelineOpenButtonContainer {
+  display: flex;
+  justify-content: center;
+  position: fixed;
+  bottom: 0;
+  pointer-events: none;
+  z-index: 150;
+  width: 100vw;
+
+  &>* {
+    pointer-events: auto;
+  }
 }
 
-.timelineStreamerColumn {
-    display: flex;
-    gap: 0.25rem;
-}
-
-.timelineBar {
-    position: relative;
-    height: 0.75rem;
-    border-radius: 0.25rem;
-    overflow: hidden;
-}
-
-.timelineBar:before {
-    content: "";
-    background: var(--mantine-color-violet-9);
-    opacity: 0.25;
-    position: absolute;
-    inset: 0;
-}
-
-.timelineBarActive {
-    pointer-events: none;
-    background-color: var(--mantine-color-violet-9);
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: var(--bar-start);
-    width: var(--bar-length);
-}
-
-.offsetInput {
-    width: 5.75rem;
-}
-
-.playheadContainer {
-    position: absolute;
-    grid-column: 2 / 3;
-    grid-row: 1;
-    width: 100%;
-    height: 100%;
-}
-
-.playhead {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: var(--playhead-position);
-    transform: translateX(-50%);
-    width: 0.125rem;
-    background-color: var(--mantine-color-grape-5);
-    opacity: 0.75;
-    pointer-events: none;
+.timelineOpenButton {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }


### PR DESCRIPTION
This PR goes in pair with https://github.com/Zibbp/ganymede/pull/355!

Adds a multistream page for playlists.
It uses playlist as a way to group multiple streams together, then allows to play them together, in sync (granted the Streamed at date is well filled.)
Accessible from the menu in the playlist page.

I had to implement another version of the video player, to allow multiple ones to be sync together. It will probably need a big refactoring between the two players (`VideoPlayer` and `SyncedVideoPlayer`) to merge them, since it would need to rework the current VOD page, and probably the chat player too.

In the multistream page, there is no chat for the moment, it will come later, after trying to refactor both the `ChatPlayer` and the `ExperimentalChatPlayer`